### PR TITLE
Test OAuth2 state parameter

### DIFF
--- a/subprocess.go
+++ b/subprocess.go
@@ -67,13 +67,17 @@ func (proc *subprocess) readLine() []string {
 	return strings.Split(line, "\t")
 }
 
-func (proc *subprocess) expect(res, descr string) string {
+func (proc *subprocess) expect(res, descr string) (string, string) {
 	cmd := proc.readLine()
 	if !assert(cmd[0] == res, descr) {
 		log.Print(cmd)
-		return ""
+		return "", ""
 	}
-	return cmd[1]
+	if len(cmd) >= 3 {
+		return cmd[1], cmd[2]
+	} else {
+		return cmd[1], ""
+	}
 }
 
 func (proc *subprocess) stop() {


### PR DESCRIPTION
The `state` parameter is part of the Portier spec and implemented by the Portier broker, but client libraries don't always implement it. This adds it to the test suite.